### PR TITLE
Remove GoatCounter analytics

### DIFF
--- a/themes/barebones/layouts/partials/footer.html
+++ b/themes/barebones/layouts/partials/footer.html
@@ -6,11 +6,6 @@
 </footer>
 {{ end }}
 
-<script
-  data-goatcounter="https://arturdryomov.goatcounter.com/count"
-  async src="//gc.zgo.at/count.js">
-</script>
-
 </body>
 
 </html>


### PR DESCRIPTION
Somehow it is blocked even more often than Google Analytics.